### PR TITLE
Add --update-to-latest flag to update all actions to their latest releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Build and Installation
+```bash
+# Install in development mode
+pip install -e .
+
+# Install from source
+pip install .
+```
+
+### Running the Tool
+```bash
+# Basic usage - convert tags to SHA in workflow files
+tag2sha .github/workflows/*.yml
+
+# Dry run - preview changes without making them
+tag2sha --dry-run .github/workflows/*.yml
+
+# Create branch, commit, and push changes
+tag2sha --branch="update-actions" --commit-msg="Update actions to use SHA" --push .github/workflows/*.yml
+
+# Convert main/master references to latest release
+tag2sha --convert-main-to-release .github/workflows/*.yml
+
+# Update all actions to their latest releases
+tag2sha --update-to-latest .github/workflows/*.yml
+
+# Update to latest with git workflow
+tag2sha --update-to-latest --branch="update-actions-latest" --commit-msg="Update all actions to latest releases" --push .github/workflows/*.yml
+```
+
+### Testing
+```bash
+# Run tests (when tests are added)
+pytest
+```
+
+## Architecture
+
+This is a command-line tool for converting GitHub Actions tag references to SHA references for improved security. The codebase consists of:
+
+**Main Components:**
+- `tag2sha/cli.py`: Core logic including:
+  - `parse_args()`: Argument parsing with support for dry-run, git operations, and branch conversion
+  - `get_commit_sha()`: Fetches SHA for tags/refs from GitHub API, handles annotated tags
+  - `get_latest_release()`: Finds the latest release tag for a repository
+  - `get_latest_matching_tag()`: Resolves version patterns (e.g., 'v4' to 'v4.1.2')
+  - `process_workflow_file()`: Parses YAML workflow files and replaces action references
+  - Git operation helpers for branch creation, commits, and pushing
+
+**Key Features:**
+- Converts GitHub Actions tag references (e.g., `actions/checkout@v4`) to SHA references with comments
+- Updates ALL actions (tags and SHAs) to their latest releases with `--update-to-latest` flag
+- Handles version patterns intelligently (e.g., `v4` resolves to latest `v4.x.x` tag)
+- Can convert `main`/`master` branch references to latest release tags
+- Supports git workflow integration (branch creation, commits, pushing)
+- Uses GitHub API with optional token authentication for rate limiting
+- Intelligently skips actions already at their latest releases to avoid unnecessary changes
+
+**Dependencies:**
+- `requests`: GitHub API interactions
+- `pyyaml`: Workflow file parsing
+- `semver`: Semantic version comparison for finding latest tags

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ tag2sha --branch="update-actions" --commit-msg="Update actions to use SHA" --pus
 # Convert main/master to latest release
 tag2sha --convert-main-to-release .github/workflows/*.yml
 
+# Update all actions to their latest releases
+tag2sha --update-to-latest .github/workflows/*.yml
+
+# Update to latest with git operations
+tag2sha --update-to-latest --branch="update-actions-latest" --commit-msg="Update all actions to latest releases" --push .github/workflows/*.yml
+
 # Skip git operations
 tag2sha --no-git .github/workflows/*.yml
 ```
@@ -31,8 +37,10 @@ tag2sha --no-git .github/workflows/*.yml
 ## Features
 
 - Converts GitHub Actions tag references to commit SHA references
+- Updates all actions (tags and SHAs) to their latest releases with `--update-to-latest`
 - Adds comments with original tag versions for reference
 - Handles version references like 'v4' by using the latest matching tag
 - Can convert 'main' branch references to the latest release
 - Supports git branch creation, commits, and pushing
-- Handles both lightweight and annotated tags 
+- Handles both lightweight and annotated tags
+- Skips updates when actions are already at their latest versions 


### PR DESCRIPTION
## Summary
- Added new `--update-to-latest` command-line flag that updates ALL GitHub Actions (whether using tags or SHA references) to their latest releases
- Enhanced regex pattern and processing logic to handle both existing and new functionality
- Smart update detection prevents unnecessary changes when actions are already at latest releases
- Added comprehensive documentation and CLAUDE.md file for future development

## Key Features Added
- **Update all actions**: Works with both tag references (`actions/checkout@v4`) and SHA references (`actions/cache@<sha>  # v3.3.1`)
- **Latest release detection**: Automatically fetches and updates to the latest release for each action
- **Smart skipping**: Avoids making changes when actions are already at their latest releases
- **Backward compatibility**: All existing functionality remains unchanged

## Examples
```bash
# Update all actions to latest releases
tag2sha --update-to-latest .github/workflows/*.yml

# Preview updates without making changes
tag2sha --update-to-latest --dry-run .github/workflows/*.yml

# Update with full git workflow
tag2sha --update-to-latest --branch="update-actions-latest" --commit-msg="Update all actions to latest releases" --push .github/workflows/*.yml
```

## What It Does
- Converts: `actions/checkout@v4` → `actions/checkout@<sha>  # v5.0.0`
- Updates: `actions/cache@<old-sha>  # v3.3.1` → `actions/cache@<new-sha>  # v4.2.4`
- Handles: `github/super-linter@main` → `github/super-linter@<sha>  # v7`
- Skips when current: No changes if already at latest releases

## Test plan
- [x] Test original functionality still works correctly
- [x] Test new `--update-to-latest` flag with various action types
- [x] Test smart skipping when already at latest versions
- [x] Test dry-run mode works correctly
- [x] Verify documentation is accurate and complete

🤖 Generated with [Claude Code](https://claude.ai/code)